### PR TITLE
feat: Fix mlflow model registration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ timm
 numpy
 pandas
 matplotlib 
-mlflow
+mlflow==2.20.2

--- a/src/chest-xray-trainer.py
+++ b/src/chest-xray-trainer.py
@@ -277,7 +277,7 @@ def main():
     p.add_argument("--total_epochs", type=int, default=20)
     p.add_argument("--initial_epochs", type=int, default=5)
     p.add_argument("--model_backbone", type=str, default="resnet18")
-    p.add_argument("--save_root", type=Path, default=Path("/models/checckpoints/"))
+    p.add_argument("--save_root", type=Path, default=Path("./checkpoints/"))
     p.add_argument("--bs", type=int, default=32)
     p.add_argument("--initial_lr", type=float, default=3e-4)
     p.add_argument("--fine_tune_lr", type=float, default=3e-5)


### PR DESCRIPTION
Deprecated mlflow client library to version 2.20.2 for compatibility with mlflow server v2.20.2 for tracking service image